### PR TITLE
fix #include<string>

### DIFF
--- a/src/MessagesQueue.hpp
+++ b/src/MessagesQueue.hpp
@@ -4,6 +4,7 @@
 #include <queue>
 #include <map>
 #include <mutex>
+#include <string>
 
 class MessagesQueue;
 
@@ -51,4 +52,4 @@ private:
 
 
 
-#endif //HIGHLOADCUP_MESSAGESQUEUE_H
+#endif // HIGHLOADCUP_MESSAGESQUEUE_H


### PR DESCRIPTION
Iostream header includes string.  But to to use std::string, it is nessesary to  #include <string>, otherwise the program might not run on different implementations, or even in later versions of the current one.